### PR TITLE
Axios 서버 요청시 검증/로그아웃 util함수 정의

### DIFF
--- a/note.txt
+++ b/note.txt
@@ -1,4 +1,18 @@
 # 로컬 mypage 브랜치를 원격 mypage 브랜치로 푸시 이때 원격 브랜치에 mypage를 생성해줌
 git push origin mypage:mypage
 
-http://52.78.248.147:8080/
+
+# axios 및 토큰 관리 
+
+유저 권한이 필요한 요청과 필요없는 요청 2가지가 존재
+
+ = 필요없는 요청은 일반 axios을 이용해 요청을 하고
+
+ = 필요한 요청은 request라는 함수를 통해 axios interceptors를 설정해 사용한다.
+ - 해당 설정은 headers에 accessToken 기입, 실제 요청값을 보내기전 토큰 검증 로직 수행 
+ - 토큰 검증 로직을 수행할 때 refreshToken상태에 따라 accessToken재 발급 및 로그아웃 처리를 수행해줘야함.
+
+로그아웃은 Recoil안에 설정된 isLogin이라는 전역 상태값으로 처리되고 있음.
+
+이는 setIsLogin()이라는 훅을 사용해 false로 변경해줘야만 로그아웃 처리가 된다.
+하지만 일반 함수에서는 훅을 사용할 수 없는 문제가 있음.

--- a/package-lock.json
+++ b/package-lock.json
@@ -16,6 +16,7 @@
         "@tanstack/react-query": "^4.33.0",
         "@tanstack/react-query-devtools": "^4.33.0",
         "axios": "^1.4.0",
+        "jwt-decode": "^3.1.2",
         "react": "^18.2.0",
         "react-dom": "^18.2.0",
         "react-router-dom": "^6.15.0",
@@ -4084,6 +4085,11 @@
       "engines": {
         "node": ">=6"
       }
+    },
+    "node_modules/jwt-decode": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/jwt-decode/-/jwt-decode-3.1.2.tgz",
+      "integrity": "sha512-UfpWE/VZn0iP50d8cz9NrZLM9lSWhcJ+0Gt/nm4by88UL+J1SiKN8/5dkjMmbEzwL2CAe+67GsegCbIKtbp75A=="
     },
     "node_modules/levn": {
       "version": "0.4.1",

--- a/package.json
+++ b/package.json
@@ -4,7 +4,6 @@
   "version": "0.0.0",
   "type": "module",
   "issue": "#20",
-
   "scripts": {
     "dev": "vite",
     "build": "tsc && vite build",
@@ -20,6 +19,7 @@
     "@tanstack/react-query": "^4.33.0",
     "@tanstack/react-query-devtools": "^4.33.0",
     "axios": "^1.4.0",
+    "jwt-decode": "^3.1.2",
     "react": "^18.2.0",
     "react-dom": "^18.2.0",
     "react-router-dom": "^6.15.0",

--- a/src/api/Axios.ts
+++ b/src/api/Axios.ts
@@ -1,0 +1,38 @@
+import axios from "axios";
+import { refresh } from "./token/refresh";
+import { SetterOrUpdater } from "recoil";
+
+export interface IAxios {
+    setIsLogin: SetterOrUpdater<boolean>
+    accessToken: string | null;
+}
+
+export const Axios = ({accessToken, setIsLogin}: IAxios) => {
+    // axios instance 생성
+    const instance = axios.create({
+        baseURL: "",
+        headers: {
+            Authorization: `${accessToken}`,
+        },
+        withCredentials: true,
+        timeout: 10 * 1000,
+    });
+
+    // instance의 interceptors 구성
+    instance.interceptors.response.use(
+        (response) => {
+            return response;
+        },
+        (error) => {
+            if(error.response.status === 401) {
+                // 해당 block은 accessToken의 만료기간이 끝났음을 의미
+                // refreshToken을 이용해 accessToken재발급 시도
+                return refresh({accessToken, setIsLogin});
+            }
+
+            return error;
+        }
+    );
+
+    return instance;
+};

--- a/src/api/token/refresh.ts
+++ b/src/api/token/refresh.ts
@@ -1,0 +1,36 @@
+import axios from "axios";
+import { IAxios } from "../Axios";
+import { LOGOUT, REFRESH_TOKEN } from "../../contance/endPoint";
+
+
+export const refresh = async ({accessToken, setIsLogin}: IAxios) => {
+    await axios.get(
+        REFRESH_TOKEN,
+        {withCredentials: true},
+    )
+    .then((response) => {
+        console.log('refresh success!');
+        localStorage.setItem('accessToken', response.data.accessToken);
+    })
+    .catch(() => {
+        // 만약 refreshToken으로 accessToken을 갱신하는데 실패하면
+        // refreshToken의 만료기간이 끝났음을 의미 로그아웃 처리해준다.
+        // 로그아웃 엔드포인트 요청
+        axios.post(LOGOUT, {
+            headers: {
+                Authorization: `Bearer ${accessToken}`,
+            },
+            withCredentials: true,
+            timeout: 10 * 1000,
+        })
+        .then((response) => {
+            // 로그아웃 요청 성공 -> 로그아웃 상태로 변경
+            if(response.status === 200) {
+                setIsLogin(false);
+            }
+        })
+        .catch((error) => {
+            return error;
+        })
+    })
+}

--- a/src/components/header/index.tsx
+++ b/src/components/header/index.tsx
@@ -2,12 +2,19 @@ import * as S from "./styled";
 
 import { useState } from "react";
 
+// Recoil
+import { useRecoilValue } from "recoil";
+import { isLogin } from "../../recoil/login/atom";
+
 // components
 import LoginModal from "../login/LoginModal";
 import ProfileIcon from "../profileIcon";
 
 
 const Header = () => {
+    // 로그인 로그아웃 위한 상태 값
+    const isLoggedIn = useRecoilValue(isLogin);
+
     const [isLoginModalOpen, setIsLoginModalOpen] = useState(false);
 
     const onClickLogin = () => {
@@ -26,10 +33,10 @@ const Header = () => {
                 </form>
             </div>
 
-        
+            {isLoggedIn ?
             <ProfileIcon /> : 
-            <button className="header__login" onClick={ onClickLogin }>Log in</button>
-
+            <button className="header__login" onClick={ onClickLogin }>Log in</button>}       
+            
             {/* Login Modal */}
             { isLoginModalOpen && <LoginModal setIsLoginModalOpen={ setIsLoginModalOpen } /> }
         </S.Header>

--- a/src/components/login/LoginForm.tsx
+++ b/src/components/login/LoginForm.tsx
@@ -2,6 +2,9 @@ import axios from "axios";
 import { useState } from "react";
 import { styled } from "styled-components";
 import { ILoginModalProp } from "./LoginModal";
+import { useSetRecoilState } from "recoil";
+import { isLogin } from "../../recoil/login/atom";
+import { LOGIN } from "../../contance/endPoint";
 
 
 const StyledLoginForm = styled.div<IShowError>`
@@ -60,7 +63,6 @@ const StyledLoginForm = styled.div<IShowError>`
 `;
 
 const LoginForm = ({setIsLoginModalOpen}: ILoginModalProp) => {
-
     const [email, setEmail] = useState('');
     const [pass, setPass] = useState('');
     
@@ -68,6 +70,7 @@ const LoginForm = ({setIsLoginModalOpen}: ILoginModalProp) => {
     const [isShowEmailError, setIsShowEmailError] = useState(false);
     const [isShowPassError, setIsShowPassError] = useState(false);
 
+    const setIsLogin = useSetRecoilState(isLogin);
 
     const onClickLogin = (event: React.FormEvent<HTMLFormElement>) => {
         event.preventDefault();
@@ -76,10 +79,11 @@ const LoginForm = ({setIsLoginModalOpen}: ILoginModalProp) => {
             password: pass
         };
         
-        axios.post('api/auth/login', Data)
+        axios.post(LOGIN, Data)
         .then((response) => {
             setIsLoginModalOpen(false);
-            localStorage.setItem("jwt", response.data.accessToken);
+            localStorage.setItem("accessToken", response.data.accessToken);
+            setIsLogin(true);
         })
         .catch((error) => {
             console.error(error);

--- a/src/components/login/SignUpForm.tsx
+++ b/src/components/login/SignUpForm.tsx
@@ -12,6 +12,7 @@ import { rangeListAtom } from "../../recoil/signup/atom.ts";
 import { useRecoilState } from "recoil";
 import axios from "axios";
 import { ILoginModalProp } from "./LoginModal.tsx";
+import { REGISTER } from "../../contance/endPoint.ts";
 
 
 const StyledSignUpForm = styled.div<IProps>`
@@ -205,7 +206,7 @@ const SignUpForm = ({setIsLoginModalOpen}: ILoginModalProp) => {
             "area_range" : areaRangeList
         }
 
-        axios.post('/api/members/signup', SignUpData)
+        axios.post(REGISTER, SignUpData)
             .then((response) => {
                 console.log(response);
                 alert('정상적으로 회원가입 되었습니다.');
@@ -227,7 +228,7 @@ const SignUpForm = ({setIsLoginModalOpen}: ILoginModalProp) => {
         return () => {
             setAreaRangeList([]);
         }
-    }, [])
+    }, [setAreaRangeList])
 
     return (
         <StyledSignUpForm isshowmessage={`${leadPassword}`}>

--- a/src/components/profileIcon/index.tsx
+++ b/src/components/profileIcon/index.tsx
@@ -1,11 +1,15 @@
 import * as S from "./styled";
 
-
 import profile from "../../assets/profile.jpeg";
+
 import { Link } from "react-router-dom";
+import { useLogout } from "../../hooks/useLogout";
+
 
 
 const ProfileIcon = () => {
+    const logout = useLogout();
+    
     return (
         <S.Profile>
             <div className="profile-wrapper">
@@ -28,7 +32,7 @@ const ProfileIcon = () => {
                         <Link to="/user/chat"><li className="ul-center__li-chat"><span>Chat</span></li></Link>
                     </ul>
                     <ul className="ul-logout">
-                        <li className="ul-logout__li-logout"><span>Log out</span></li>
+                        <li className="ul-logout__li-logout"><span onClick={logout}>Log out</span></li>
                     </ul>
                 </div>
             </div>

--- a/src/components/profileIcon/styled.ts
+++ b/src/components/profileIcon/styled.ts
@@ -71,6 +71,7 @@ export const Profile = styled.div`
             padding: 1rem 0;
         }
         .ul-logout {
+            cursor: pointer;
             padding-top: 1rem;
             padding-bottom: 0;
             border-top: 0.1px solid gray;

--- a/src/contance/endPoint.ts
+++ b/src/contance/endPoint.ts
@@ -1,0 +1,21 @@
+// 회원가입 - REGISTER
+// 로그인 - LOGIN
+// 로그아웃 - LOGOUT
+// 토큰 재발급 - REFRESH_TOKEN
+// 회원정보 수정 - UPDATE_PROFILE
+// 회원 비밀번호 수정 - UPDATE_PASSWORD
+// 회원 단건 조회(본인) - GET_SELF_MEMBER
+// 회원 단건 조회(상대방) - GET_OTHER_MEMBER + {memberId}
+// 회원 전체 조회 - GET_ALL_MEMBERS
+// 회원탈퇴 - DELETE_MEMBER
+
+export const REGISTER = '/api/members/signup';
+export const LOGIN = '/api/auth/login';
+export const LOGOUT = '/api/auth/logout'
+export const REFRESH_TOKEN = '/api/auth/token-refresh';
+export const UPDATE_PROFILE = '/api/members/myProfile';
+export const UPDATE_PASSWORD = '/api/members/myProfile/password';
+export const GET_SELF_MEMBER = '/api/members/mypage';
+export const GET_OTHER_MEMBER = '/api/members/';
+export const GET_ALL_MEMBERS = '/api/members';
+export const DELETE_MEMBER = '/api/members/myProfile';

--- a/src/hooks/useAxios.ts
+++ b/src/hooks/useAxios.ts
@@ -1,0 +1,12 @@
+import { useSetRecoilState } from "recoil"
+import { isLogin } from "../recoil/login/atom"
+import { Axios } from "../api/Axios";
+
+export const useAxios = () => {
+    const setIsLogin = useSetRecoilState(isLogin);
+    const accessToken = localStorage.getItem('accessToken');
+
+    const request = Axios({accessToken, setIsLogin});
+    
+    return request;
+}

--- a/src/hooks/useLogout.ts
+++ b/src/hooks/useLogout.ts
@@ -1,0 +1,35 @@
+import { useSetRecoilState } from "recoil";
+import { isLogin } from "../recoil/login/atom";
+import axios from "axios";
+import { LOGOUT } from "../contance/endPoint";
+
+export const useLogout = () => {
+    const setIsLogin = useSetRecoilState(isLogin);
+    
+    const logout = () => {
+        console.log('onClick! logout');
+        const accessToken = localStorage.getItem('accessToken');
+        
+        axios.post(LOGOUT, {}, {
+            headers: {
+                Authorization: `${accessToken}`,
+            },
+            withCredentials: true,
+            timeout: 10 * 1000,
+        })
+        .then((response) => {
+            // 로그아웃 요청 성공 -> 로그아웃 상태로 변경
+            if(response.status === 200) {
+                localStorage.removeItem('accessToken');
+                setIsLogin(false);
+            }
+            console.log(response);
+            return response;
+        })
+        .catch((error) => {
+            console.error(error);
+            return error;
+        })
+    }
+    return logout;
+}

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -7,7 +7,7 @@ import { RecoilRoot } from "recoil";
 import Home from "./pages/Home";
 import Products from "./pages/Products";
 import Community from "./pages/Community";
-import Trade from "./pages/Trade";
+// import Trade from "./pages/Trade";
 import ErrorPage from "./pages/Error";
 
 import GlobalStyles from "./style/GlobalStyles";
@@ -17,6 +17,7 @@ import ProfilePage from "./pages/ProfilePage";
 import Dashboard from "./pages/ProfilePage/dashboard";
 import Chat from "./pages/ProfilePage/chat";
 import Profile from "./pages/ProfilePage/profile";
+
 
 const queryClient = new QueryClient({
     defaultOptions: {
@@ -52,7 +53,7 @@ const router = createBrowserRouter([
             },
             {
                 path: "trade",
-                element: <Trade />,
+                // element: <Trade />,
             },
         ],
     },

--- a/src/pages/ProfilePage/index.tsx
+++ b/src/pages/ProfilePage/index.tsx
@@ -7,9 +7,15 @@ import { faAddressCard, faCommentDots } from "@fortawesome/free-regular-svg-icon
 import { faTableColumns } from "@fortawesome/free-solid-svg-icons";
 
 import profile from "../../assets/profile.jpeg";
+import { useLogout } from "../../hooks/useLogout";
+import { useEffect } from "react";
+import { useAxios } from "../../hooks/useAxios";
 
 
 const ProfilePage = () => {
+    const logout = useLogout();
+    const request = useAxios();
+    
     const url = useLocation().pathname.slice(1);
     let isAddNow = false;
     let location = '';
@@ -22,6 +28,18 @@ const ProfilePage = () => {
             location += url[i];
         }
     }
+    // FIXME TESTCODE 정상 작동 
+    // TODO 회원 단건 조회 엔드포인트 응답 400
+    // TODO 회원 전체 조회는 응답 200ok
+    useEffect(() => {
+        request.get('/api/members')
+            .then((response) => {
+                console.log(response);
+            })
+            .catch((error) => {
+                console.error(error);
+            })
+    }, [request]);
 
     const nickname="닉네임";
     const email="jsj2505@gmail.com";
@@ -64,7 +82,7 @@ const ProfilePage = () => {
                 </S.Ul>
 
                 <div className="profile-page__left__logout">
-                    <span>로그아웃</span>
+                    <Link to="/"><span onClick={logout}>로그아웃</span></Link>
                 </div>
             </S.ProfilePageLeft>
 

--- a/src/pages/ProfilePage/profile/index.tsx
+++ b/src/pages/ProfilePage/profile/index.tsx
@@ -98,18 +98,18 @@ const Profile = () => {
                             <FontAwesomeIcon icon={faHandshake} />
                             <div className="range__current__area-range">
                             {
-                                currentAreaRange.map((location) => (
-                                    <span className="location-item">{location}</span>
+                                currentAreaRange.map((location, index) => (
+                                    <span className="location-item" key={index}>{location}</span>
                                 ))
                             }
                             {
-                                currentAreaRange.map((location) => (
-                                    <span className="location-item">{location}</span>
+                                currentAreaRange.map((location, index) => (
+                                    <span className="location-item" key={index}>{location}</span>
                                 ))
                             }
                             {
-                                currentAreaRange.map((location) => (
-                                    <span className="location-item">{location}</span>
+                                currentAreaRange.map((location, index) => (
+                                    <span className="location-item" key={index}>{location}</span>
                                 ))
                             }
                             </div>

--- a/src/recoil/login/atom.ts
+++ b/src/recoil/login/atom.ts
@@ -1,0 +1,6 @@
+import { atom } from "recoil";
+
+export const isLogin = atom({
+    key: 'isLogin',
+    default: localStorage.getItem('accessToken') != null
+})

--- a/src/util/pastTimeCalculator.ts
+++ b/src/util/pastTimeCalculator.ts
@@ -1,4 +1,3 @@
-
 // 생성 시간에서 현재까지 지난 시간을 계산하여 "~일 전", "~시간 전" 같은 문자열 반환
 const pastTimeCalculator = (created_at: string) => {
     const parsed = Date.parse(created_at);


### PR DESCRIPTION
권한이 필요한 요청시 수행되어질 로직들을 useAxios을 통해 return되는 Axios instance를 통해 수행하도록 구현함 #34 

사용법
- 권한이 필요한 요청을 보낼 때 

`const request = useAxios()`

`request.get or request.post ...`

토큰의 상태에 따라 accessToken의 재발급과 로그아웃 처리를 하도록 작성됨

+ 앤드포인트에 접근시 상수를 사용할 수 있게 endPoint.ts 파일이 추가됨.


- 권한이 필요한 end point에 요청시 accessToken, refreshToken을 항상 넣어주도록 함.
- 서버에 accessToken이 만료된 상태로 보내질 경우 refreshToken을 이용해 재발급 받도록 interceptors 설정
- 서버에 건내준 refreshToken이 만료되었다면 로그아웃 처리